### PR TITLE
add configuration files to grasp hot glue gun

### DIFF
--- a/mobipick_pick_n_place/config/grasplan/object_grasps/gripper_distance_values_per_object.yaml
+++ b/mobipick_pick_n_place/config/grasplan/object_grasps/gripper_distance_values_per_object.yaml
@@ -6,6 +6,7 @@ distance_gripper_close_per_obj:
     multimeter: 0.052
     relay: 0.04
     power_drill_with_grip: 0.03
+    hot_glue_gun: 0.025
 
 # dictionary of distances in meters that the gripper should open before grasping the objects
 # if object is not specified, it will open the default value

--- a/mobipick_pick_n_place/config/grasplan/object_grasps/handcoded_grasp_planner_hot_glue_gun.yaml
+++ b/mobipick_pick_n_place/config/grasplan/object_grasps/handcoded_grasp_planner_hot_glue_gun.yaml
@@ -1,0 +1,9 @@
+# this file was generated automatically by grasplan grasp editor
+hot_glue_gun:
+  grasp_poses:
+    -
+      translation: [0.030000, -0.085000, 0.000000]
+      rotation: [-0.500000, -0.500000, 0.500000, 0.500000]
+    -
+      translation: [0.030000, -0.085000, 0.000000]
+      rotation: [0.500000, 0.500000, 0.500000, 0.500000]

--- a/mobipick_pick_n_place/config/grasplan/pick_params.yaml
+++ b/mobipick_pick_n_place/config/grasplan/pick_params.yaml
@@ -57,4 +57,5 @@ list_of_disentangle_objects:
     - 'klt'
     - 'relay'
     - 'power_drill_with_grip'
+    - 'hot_glue_gun'
     - 'screwdriver'


### PR DESCRIPTION
added:

- distance that the gripper should close when grasping hot glue gun
- grasp transformations recorded using grasplan toolbox
- add hot glue gun to list of disentangle objects