### PR TITLE
add files to teach poses in grasplan with gazebo

### DIFF
--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -3,6 +3,10 @@
     uri: https://github.com/BehaviorTree/Groot.git
     version: master
 - git:
+    local-name: april_gazebo_plugins
+    uri: https://github.com/aprilprojecteu/april_gazebo_plugins
+    version: noetic
+- git:
     local-name: astra_camera
     uri: https://github.com/orbbec/ros_astra_camera.git
     version: aff227d6

--- a/mobipick_description/package.xml
+++ b/mobipick_description/package.xml
@@ -22,6 +22,7 @@
   <exec_depend>gazebo_grasp_plugin</exec_depend> <!-- from https://github.com/JenniferBuehler/gazebo-pkgs -->
   <exec_depend>gazebo_logical_camera_plugin_ros</exec_depend>
   <exec_depend>gazebo_ros_control</exec_depend>
+  <exec_depend>gazebo_ros_vel</exec_depend>
   <exec_depend>joint_state_controller</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>

--- a/mobipick_description/urdf/robotiq_2f_140/robotiq_arg2f_140_model_macro.xacro
+++ b/mobipick_description/urdf/robotiq_2f_140/robotiq_arg2f_140_model_macro.xacro
@@ -240,6 +240,9 @@
   </xacro:macro>
 
   <!-- GRASP HACK -->
-  <xacro:include filename="$(find mobipick_description)/urdf/robotiq_2f_140/gzplugin_grasp_fix.urdf.xacro"/>
-  <xacro:gzplugin_grasp_fix prefix="${prefix}"/>
+  <xacro:property name="grasp_fix_required" default="true" />
+  <xacro:if value="${grasp_fix_required}">
+    <xacro:include filename="$(find mobipick_description)/urdf/robotiq_2f_140/gzplugin_grasp_fix.urdf.xacro"/>
+    <xacro:gzplugin_grasp_fix prefix="${prefix}"/>
+  </xacro:if>
 </robot>

--- a/mobipick_description/urdf/robotiq_2f_140/robotiq_arg2f_140_model_sim_floating.urdf.xacro
+++ b/mobipick_description/urdf/robotiq_2f_140/robotiq_arg2f_140_model_sim_floating.urdf.xacro
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<robot name="robotiq_arg2f_140_model" xmlns:xacro="http://ros.org/wiki/xacro">
+
+  <xacro:arg name="tf_prefix" default="" />
+  <xacro:property name="tf_prefix_" value="$(arg tf_prefix)" />
+  <xacro:if value="${tf_prefix_ == ''}">
+    <xacro:property name="prefix" value="" />
+  </xacro:if>
+  <xacro:unless value="${tf_prefix_ == ''}">
+    <xacro:property name="prefix" value="${tf_prefix_}/" />
+  </xacro:unless>
+
+  <xacro:property name="grasp_fix_required" value="false" /> <!-- do not use grasp fix plugin -->
+  <xacro:include filename="$(find mobipick_description)/urdf/robotiq_2f_140/robotiq_arg2f_140_model_macro.xacro" />
+  <xacro:include filename="$(find mobipick_description)/urdf/common.gazebo.xacro" />
+  <xacro:include filename="$(find mobipick_description)/urdf/robotiq_2f_140/robotiq_2f_140.gazebo.xacro" />
+
+  <xacro:robotiq_arg2f_140 prefix="${prefix}gripper_"/>
+  <xacro:controller_plugin_gazebo robot_namespace=""/>
+  <xacro:mimic_joint_plugins_gazebo prefix="${prefix}gripper_" robot_namespace=""/>
+
+  <!-- plugin to exert a velocity on a link, see:
+       https://github.com/aprilprojecteu/april_gazebo_plugins -->
+  <gazebo>
+    <plugin name="gazebo_ros_vel" filename="libgazebo_ros_vel.so">
+      <bodyName>${prefix}gripper_robotiq_arg2f_base_link</bodyName>
+      <topicName>cmd_vel</topicName>
+    </plugin>
+  </gazebo>
+
+</robot>

--- a/mobipick_gazebo/launch/robotiq_2f_140/robotiq_2f_140_floating.gazebo.launch
+++ b/mobipick_gazebo/launch/robotiq_2f_140/robotiq_2f_140_floating.gazebo.launch
@@ -5,7 +5,7 @@
 
   <arg name="gui" default="true" />
   <!-- Note: the world_name is with respect to GAZEBO_RESOURCE_PATH environmental variable, but can also be an absolute path -->
-  <arg name="world_name" default="worlds/zero_gravity_empty_world.sdf"/>
+  <arg name="world_name" default="$(find mobipick_gazebo)/worlds/zero_gravity_empty_world.sdf"/>
 
   <arg name="gripper_x"   default="0.0" />
   <arg name="gripper_y"   default="0.0" />

--- a/mobipick_gazebo/launch/robotiq_2f_140/robotiq_2f_140_floating.gazebo.launch
+++ b/mobipick_gazebo/launch/robotiq_2f_140/robotiq_2f_140_floating.gazebo.launch
@@ -1,0 +1,88 @@
+<?xml version="1.0" ?>
+<launch>
+
+  <!-- This launch file is used to bringup the robotiq_2f_140 gripper in a zero gravity environment to easily record grasp poses -->
+
+  <arg name="gui" default="true" />
+  <!-- Note: the world_name is with respect to GAZEBO_RESOURCE_PATH environmental variable, but can also be an absolute path -->
+  <arg name="world_name" default="worlds/zero_gravity_empty_world.sdf"/>
+
+  <arg name="gripper_x"   default="0.0" />
+  <arg name="gripper_y"   default="0.0" />
+  <arg name="gripper_z"   default="0.0" />
+  <arg name="gripper_roll" default="0.0" />
+  <arg name="gripper_pitch" default="0.0" />
+  <arg name="gripper_yaw" default="0.0" />
+
+  <arg name="namespace" default="robotiq_arg2f" doc="Namespace to push all topics into"/>
+  <arg name="tf_prefix" default="robotiq_arg2f" doc="tf_prefix to be used" />
+  <arg name="robot_name" default="robotiq_arg2f" doc="Sets the name of the robot in gazebo" />
+
+  <arg name="start_paused" default="true" />
+
+  <remap from="$(arg namespace)/joint_states" to="$(arg namespace)/gazebo_joint_states" />
+
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="world_name" value="$(arg world_name)"/>
+    <arg name="paused" value="$(arg start_paused)" />
+    <arg name="gui" value="$(arg gui)" />
+  </include>
+
+  <group ns="$(arg namespace)">
+
+    <!-- Add passive + mimic joints to joint_states topic -->
+    <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher">
+      <rosparam param="source_list">[gazebo_joint_states]</rosparam>
+      <param name="rate" value="60.0" />
+    </node>
+
+    <!-- $(arg prefix) is used in all the config files!
+         TODO: For multiple robots, create groups when loading the parameters to overwrite the arg? -->
+    <arg name="prefix" value="$(arg tf_prefix)/" if="$(eval tf_prefix != '')" />
+    <!-- Cannot use '$(arg tf_prefix)/' instead because '/' would be included if tf_prefix = '', and tf frames cannot start with '/' in tf2 -->
+    <arg name="prefix" value="" unless="$(eval tf_prefix != '')" />
+
+    <!-- Load URDF -->
+    <param name="robot_description"
+           command="$(find xacro)/xacro $(find mobipick_description)/urdf/robotiq_2f_140/robotiq_arg2f_140_model_sim_floating.urdf.xacro
+                    tf_prefix:=$(arg tf_prefix)" />
+
+    <!-- Load gazebo controller configurations -->
+    <!-- Note: You MUST load these PID parameters for all joints that are using
+        the PositionJointInterface, otherwise the arm + gripper will act like a
+        giant parachute, counteracting gravity, and causing some of the wheels
+        to lose contact with the ground, so the robot won't be able to properly
+        navigate. See
+        https://github.com/ros-simulation/gazebo_ros_pkgs/issues/612 -->
+    <rosparam file="$(find mobipick_gazebo)/config/robotiq_2f_140/gazebo_controller.yaml" command="load" subst_value="true" />
+    <rosparam file="$(find mobipick_gazebo)/config/robotiq_2f_140/gazebo_mimic_joint.yaml" command="load" subst_value="true" />
+
+    <!-- Spawn the robot into Gazebo -->
+    <!-- Don't set ur5_shoulder_lift_joint to values smaller than -2.16 (for example, -2.60), otherwise Gazebo adds 2 pi to the reported joint_states -->
+    <node name="spawn_urdf" pkg="gazebo_ros" type="spawn_model" args="-param robot_description -urdf -model $(arg robot_name)
+               -x $(arg gripper_x) -y $(arg gripper_y) -z $(arg gripper_z)
+               -R $(arg gripper_roll) -P $(arg gripper_pitch) -Y $(arg gripper_yaw) " />
+
+    <!-- Load ros_control controller configurations -->
+    <rosparam file="$(find mobipick_description)/config/joint_state_controller.yaml" command="load" subst_value="true" />
+    <rosparam file="$(find mobipick_description)/config/robotiq_2f_140/joint_trajectory_controller.yaml" command="load" subst_value="true" />
+
+    <!-- Start the controllers -->
+    <node name="controller_spawner" pkg="controller_manager" type="controller_manager" output="screen"
+          args="spawn joint_state_controller gripper_controller" />
+
+    <!-- Robot state publisher -->
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" output="screen" />
+
+    <!-- rqt joint trajectory -->
+    <node name="rqt_joint_trajectory_controller" pkg="rqt_joint_trajectory_controller" type="rqt_joint_trajectory_controller" />
+
+  </group>
+
+  <!-- Robotiq command bridge -->
+  <include file="$(find mobipick_gazebo)/launch/robotiq_2f_140/robotiq_2f_140_bridge.launch">
+    <arg name="namespace" value="$(arg namespace)" />
+    <arg name="tf_prefix" value="$(arg tf_prefix)" />
+  </include>
+
+</launch>

--- a/mobipick_gazebo/worlds/zero_gravity_empty_world.sdf
+++ b/mobipick_gazebo/worlds/zero_gravity_empty_world.sdf
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<sdf version='1.4'>
+  <world name='zero_gravity_empty_world'>
+
+    <!-- no gravity -->
+    <gravity>0 0 0</gravity>
+
+    <!-- A global light source -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <scene>
+      <ambient>0.4 0.4 0.4 1</ambient>
+      <background>0.7 0.7 0.7 1</background>
+      <shadows>false</shadows>
+    </scene>
+
+    <gui fullscreen='0'>
+      <camera name='user_camera'>
+        <pose>4.3 2.3 3.3 0 0.45 -2.8</pose>
+        <view_controller>orbit</view_controller>
+      </camera>
+    </gui>
+
+  </world>
+</sdf>


### PR DESCRIPTION
Files required by Grasplan to record grasps using Gazebo simulation. The idea is to spawn only the Mobipick gripper in simulation and control it via velocity commands in a free-floating world with no gravity,

see https://youtu.be/osATE2MKjYU?si=Z3yQiFkM0wS_GKPl