### PR TITLE
configure launch files for a faster simulation by default

### DIFF
--- a/mobipick_gazebo/launch/mobipick/mobipick_empty_world.launch
+++ b/mobipick_gazebo/launch/mobipick/mobipick_empty_world.launch
@@ -16,6 +16,7 @@
     doc="Can be 'astra' for Orbbec Astra Mini S, 'intel_d455' for Intel RealSense D455 or 'intel_d435' for Intel RealSense D435, changes the main 3D camera." />
 
   <arg name="start_paused" default="true" />
+  <arg name="physics_profile" default="fast" doc="options: slow, fast" />
 
   <group>
     <remap from="$(arg namespace)/mobile_base_controller/cmd_vel" to="$(arg namespace)/cmd_vel" />
@@ -26,6 +27,7 @@
       <arg name="world_name" value="$(arg world_name)"/>
       <arg name="paused" value="$(arg start_paused)" />
       <arg name="gui" value="$(arg gui)" />
+      <arg name="extra_gazebo_args" value="--profile $(arg physics_profile)" />
     </include>
   </group>
 

--- a/mobipick_gazebo/launch/mobipick/mobipick_maze_world.launch
+++ b/mobipick_gazebo/launch/mobipick/mobipick_maze_world.launch
@@ -3,11 +3,13 @@
   <arg name="gui" default="true" />
   <arg name="arm_controller" default="trajectory" doc="Which arm controller to start. Options are trajectory, velocity, position" />
   <arg name="robot"      default="mobipick-os" doc="Which variant of the mobipick? Can be 'mobipick-hb' or 'mobipick-os'" />
+  <arg name="physics_profile" default="fast" doc="options: slow, fast" />
 
   <include file="$(find mobipick_gazebo)/launch/mobipick/mobipick_empty_world.launch">
     <arg name="robot" value="$(arg robot)" />
     <arg name="gui" value="$(arg gui)" />
     <arg name="arm_controller" value="$(arg arm_controller)" />
+    <arg name="physics_profile" value="$(arg physics_profile)" />
   </include>
 
   <include file="$(find mir_gazebo)/launch/includes/spawn_maze.launch.xml" />

--- a/mobipick_gazebo/launch/mobipick/mobipick_moelk.launch
+++ b/mobipick_gazebo/launch/mobipick/mobipick_moelk.launch
@@ -7,6 +7,7 @@
 
   <arg name="gui" default="true" />
   <arg name="start_paused" default="true" />
+  <arg name="physics_profile" default="fast" doc="options: slow, fast" />
   <arg name="arm_controller" default="trajectory" doc="Which arm controller to start. Options are trajectory, velocity, position" />
 
   <include file="$(find mobipick_gazebo)/launch/mobipick/mobipick_empty_world.launch">
@@ -21,6 +22,7 @@
     <arg name="robot_x"   value="11.00" />
     <arg name="robot_y"   value="3.00" />
     <arg name="robot_yaw" value="0.00" />
+    <arg name="physics_profile" value="$(arg physics_profile)" />
   </include>
 
   <!-- spawn power drill -->

--- a/mobipick_gazebo/launch/mobipick/mobipick_mrk_lab_world.launch
+++ b/mobipick_gazebo/launch/mobipick/mobipick_mrk_lab_world.launch
@@ -4,6 +4,7 @@
   <arg name="robot"     default="mobipick-os" doc="Which variant of the mobipick? Can be 'mobipick-hb' or 'mobipick-os'" />
   <arg name="gui" default="true" />
   <arg name="start_paused" default="true" />
+  <arg name="physics_profile" default="fast" doc="options: slow, fast" />
   <arg name="arm_controller" default="trajectory" doc="Which arm controller to start. Options are trajectory, velocity, position" />
 
   <include file="$(find mobipick_gazebo)/launch/mobipick/mobipick_empty_world.launch">
@@ -15,6 +16,7 @@
     <arg name="robot_y"   value="11.327" />
     <arg name="robot_yaw" value="1.57" />
     <arg name="start_paused" value="$(arg start_paused)" />
+    <arg name="physics_profile" value="$(arg physics_profile)" />
   </include>
 
   <!-- spawn power drill -->

--- a/mobipick_gazebo/launch/mobipick/mobipick_smart_factory.launch
+++ b/mobipick_gazebo/launch/mobipick/mobipick_smart_factory.launch
@@ -3,6 +3,7 @@
   <arg name="namespace" default="mobipick" doc="Namespace to push all topics into"/>
   <arg name="robot"     default="mobipick-os" doc="Which variant of the mobipick? Can be 'mobipick-hb' or 'mobipick-os'" />
   <arg name="gui" default="true" />
+  <arg name="physics_profile" default="fast" doc="options: slow, fast" />
   <arg name="arm_controller" default="trajectory" doc="Which arm controller to start. Options are trajectory, velocity, position" />
 
   <include file="$(find mobipick_gazebo)/launch/mobipick/mobipick_empty_world.launch">
@@ -13,6 +14,7 @@
     <arg name="robot_x"   value="5.00" />
     <arg name="robot_y"   value="2.00" />
     <arg name="robot_yaw" value="0.00" />
+    <arg name="physics_profile" value="$(arg physics_profile)" />
   </include>
   <param name="world" type="str" value="smart_factory" />
 

--- a/mobipick_gazebo/launch/mobipick/mobipick_table_world.launch
+++ b/mobipick_gazebo/launch/mobipick/mobipick_table_world.launch
@@ -2,12 +2,14 @@
 <launch>
   <arg name="robot" default="mobipick-os" doc="Which variant of the mobipick? Can be 'mobipick-hb' or 'mobipick-os'" />
   <arg name="gui" default="true" />
+  <arg name="physics_profile" default="fast" doc="options: slow, fast" />
   <arg name="arm_controller" default="trajectory" doc="Which arm controller to start. Options are trajectory, velocity, position" />
 
   <include file="$(find mobipick_gazebo)/launch/mobipick/mobipick_empty_world.launch">
     <arg name="robot" value="$(arg robot)" />
     <arg name="gui" value="$(arg gui)" />
     <arg name="arm_controller" value="$(arg arm_controller)" />
+    <arg name="physics_profile" value="$(arg physics_profile)" />
   </include>
 
   <!-- spawn power drill -->

--- a/mobipick_gazebo/launch/mobipick/tables_demo.launch
+++ b/mobipick_gazebo/launch/mobipick/tables_demo.launch
@@ -10,6 +10,7 @@
 
   <arg name="gui" default="true" />
   <arg name="start_paused" default="true" />
+  <arg name="physics_profile" default="fast" doc="options: slow, fast" />
   <arg name="arm_controller" default="trajectory" doc="Which arm controller to start. Options are trajectory, velocity, position" />
 
   <!-- the pose where to spawn the robot in simulation -->
@@ -29,6 +30,7 @@
     <arg name="robot_x"   value="$(arg robot_x)" />
     <arg name="robot_y"   value="$(arg robot_y)" />
     <arg name="robot_yaw" value="$(arg robot_yaw)" />
+    <arg name="physics_profile" value="$(arg physics_profile)" />
   </include>
 
   <!-- spawn objects in the simulated world -->


### PR DESCRIPTION
Makes Gazebo simulation faster, however it keeps the option to run it at normal speed.