### PR TITLE
Fix fast physics

### DIFF
--- a/mobipick_description/urdf/robotiq_2f_140/gzplugin_grasp_fix.urdf.xacro
+++ b/mobipick_description/urdf/robotiq_2f_140/gzplugin_grasp_fix.urdf.xacro
@@ -30,7 +30,7 @@
              Note that in-between such updates, existing contact points may be collected at a higher rate
              (the Gazebo world update rate). The update_rate is only the rate at which they are processed,
               which takes a bit of computation time, and therefore should be lower than the gazebo world update rate. -->
-        <update_rate>50</update_rate>
+        <update_rate>100</update_rate> <!-- 50 is fine for slow physics, but 100 is required for fast physics -->
 
         <!-- Is the number of times in the update loop (running at update_rate) that an object has to be detected as "gripped"
              in order to attach the object. Adjust this with the update rate.-->

--- a/mobipick_description/urdf/robotiq_2f_140/robotiq_fingertips_65mm.xacro
+++ b/mobipick_description/urdf/robotiq_2f_140/robotiq_fingertips_65mm.xacro
@@ -23,9 +23,11 @@
         <xacro:insert_block name="material_grey" />
       </visual>
       <collision>
-        <origin xyz="0 0 0" rpy="0 0 0" />
+        <origin xyz="0.00005 0.0325 -0.0035" rpy="0 0 0"/>
         <geometry>
-          <mesh filename="package://mobipick_description/meshes/robotiq_2f_140/robotiq_arg2f_${stroke}_fingertip_65mm.stl" />
+          <!-- <mesh filename="package://mobipick_description/meshes/robotiq_2f_140/robotiq_arg2f_${stroke}_fingertip_65mm.stl" /> -->
+          <!-- using box instead of mesh for collision produces less vibration of the fingers when grasping objects -->
+          <box size="0.0271 0.065 0.007"/> <!-- values ok for stroke of 140, only? -->
         </geometry>
       </collision>
     </link>

--- a/mobipick_description/urdf/robotiq_2f_140/robotiq_fingertips_65mm.xacro
+++ b/mobipick_description/urdf/robotiq_2f_140/robotiq_fingertips_65mm.xacro
@@ -36,6 +36,12 @@
       <!-- high friction value to prevent objects from slipping the gripper fingers -->
       <mu1>5.0</mu1>
       <mu2>5.0</mu2>
+      <!-- a low kp (stiffness value) allows some penetration of the material making the gripper "soft".
+           The reason to prefer a soft gripper is to increase friction by increasing the contact area,
+           specially when the surface of the object to grasp is irregular, e.g. a mesh
+           see: https://classic.gazebosim.org/tutorials?tut=physics_params&cat=physics -->
+      <kp>5000.0</kp> <!-- 5000.0 - medium gripper finger "softness", 1000000.0 - hard/rigid gripper finger -->
+      <kd>1.0</kd>
     </gazebo>
   </xacro:macro>
 

--- a/mobipick_description/urdf/robotiq_2f_140/robotiq_fingertips_65mm.xacro
+++ b/mobipick_description/urdf/robotiq_2f_140/robotiq_fingertips_65mm.xacro
@@ -33,6 +33,9 @@
     </link>
     <gazebo reference="${prefix}${fingerprefix}_robotiq_fingertip_65mm">
       <material>Gazebo/Grey</material>
+      <!-- high friction value to prevent objects from slipping the gripper fingers -->
+      <mu1>5.0</mu1>
+      <mu2>5.0</mu2>
     </gazebo>
   </xacro:macro>
 

--- a/mobipick_gazebo/urdf/coke_can.urdf.xacro
+++ b/mobipick_gazebo/urdf/coke_can.urdf.xacro
@@ -22,4 +22,12 @@
       </geometry>
     </collision>
   </link>
+
+  <gazebo reference="coke_can">
+    <mu1>5.0</mu1> <!-- high friction -->
+    <mu2>5.0</mu2>
+    <kp>1e+06</kp> <!-- high stiffness -->
+    <kd>1.0</kd> <!-- normal damping -->
+  </gazebo>
+
 </robot>

--- a/mobipick_gazebo/urdf/hot_glue_gun.urdf.xacro
+++ b/mobipick_gazebo/urdf/hot_glue_gun.urdf.xacro
@@ -28,4 +28,12 @@
       </geometry>
     </collision>
   </link>
+
+  <gazebo reference="hot_glue_gun">
+    <mu1>5.0</mu1> <!-- high friction -->
+    <mu2>5.0</mu2>
+    <kp>1e+06</kp> <!-- high stiffness -->
+    <kd>1.0</kd> <!-- normal damping -->
+  </gazebo>
+
 </robot>

--- a/mobipick_gazebo/urdf/klt.urdf.xacro
+++ b/mobipick_gazebo/urdf/klt.urdf.xacro
@@ -73,4 +73,12 @@
     </collision>
 
   </link>
+
+  <gazebo reference="klt">
+    <mu1>5.0</mu1> <!-- high friction -->
+    <mu2>5.0</mu2>
+    <kp>1e+06</kp> <!-- high stiffness -->
+    <kd>1.0</kd> <!-- normal damping -->
+  </gazebo>
+
 </robot>

--- a/mobipick_gazebo/urdf/multimeter.urdf.xacro
+++ b/mobipick_gazebo/urdf/multimeter.urdf.xacro
@@ -32,4 +32,12 @@
       </geometry>
     </collision>
   </link>
+
+  <gazebo reference="multimeter">
+    <mu1>5.0</mu1> <!-- high friction -->
+    <mu2>5.0</mu2>
+    <kp>1e+06</kp> <!-- high stiffness -->
+    <kd>1.0</kd> <!-- normal damping -->
+  </gazebo>
+
 </robot>

--- a/mobipick_gazebo/urdf/power_drill.urdf.xacro
+++ b/mobipick_gazebo/urdf/power_drill.urdf.xacro
@@ -31,4 +31,12 @@
       </geometry>
     </collision>
   </link>
+
+  <gazebo reference="power_drill">
+    <mu1>5.0</mu1> <!-- high friction -->
+    <mu2>5.0</mu2>
+    <kp>1e+06</kp> <!-- high stiffness -->
+    <kd>1.0</kd> <!-- normal damping -->
+  </gazebo>
+
 </robot>

--- a/mobipick_gazebo/urdf/power_drill_with_grip.urdf.xacro
+++ b/mobipick_gazebo/urdf/power_drill_with_grip.urdf.xacro
@@ -28,4 +28,12 @@
       </geometry>
     </collision>
   </link>
+
+  <gazebo reference="power_drill_with_grip">
+    <mu1>5.0</mu1> <!-- high friction -->
+    <mu2>5.0</mu2>
+    <kp>1e+06</kp> <!-- high stiffness -->
+    <kd>1.0</kd> <!-- normal damping -->
+  </gazebo>
+
 </robot>

--- a/mobipick_gazebo/urdf/relay.urdf.xacro
+++ b/mobipick_gazebo/urdf/relay.urdf.xacro
@@ -32,4 +32,12 @@
       </geometry>
     </collision>
   </link>
+
+  <gazebo reference="relay">
+    <mu1>5.0</mu1> <!-- high friction -->
+    <mu2>5.0</mu2>
+    <kp>1e+06</kp> <!-- high stiffness -->
+    <kd>1.0</kd> <!-- normal damping -->
+  </gazebo>
+
 </robot>

--- a/mobipick_gazebo/urdf/screwdriver.urdf.xacro
+++ b/mobipick_gazebo/urdf/screwdriver.urdf.xacro
@@ -32,4 +32,12 @@
       </geometry>
     </collision>
   </link>
+
+  <gazebo reference="screwdriver">
+    <mu1>5.0</mu1> <!-- high friction -->
+    <mu2>5.0</mu2>
+    <kp>1e+06</kp> <!-- high stiffness -->
+    <kd>1.0</kd> <!-- normal damping -->
+  </gazebo>
+
 </robot>


### PR DESCRIPTION
Short: Solves https://github.com/DFKI-NI/pbr_tools/issues/4

Long: This branch solves a problem where the power_drill_with_grip was not able to be grasped with fast ode physics params.

NOTE: only changes in this repo are necessary for the fix

Main changes:
- friction, stiffness and damping parameters were properly set for mobipick fingers and objects as well
- update rate of gazebo grasp fix was increased to cope with fast physics

Minor improvements:
- gripper fingers collision model replaced from mesh to box to reduce vibration